### PR TITLE
Remove options field from scaleManifest stage

### DIFF
--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -365,7 +365,7 @@
       withAccount(account):: self + { account: account },
       withNamespace(namespace):: self + { location: namespace },
       withReplicas(replicas):: self + { replicas: replicas },
-      withManifestName(kind, name):: self.options { manifestName: kind + ' ' + name },
+      withManifestName(kind, name):: self + { manifestName: kind + ' ' + name },
     },
     undoRolloutManifest(name): stage(name, 'undoRolloutManifest') {
       cloudProvider: 'kubernetes',


### PR DESCRIPTION
In `scaleManifest` stage function `withManifestName` tries to modify `options` field, which does not exist.
This results in error:
```
RUNTIME ERROR: Field does not exist: options
	/home/rafal/projects/floodgate/sponnet/pipeline.libsonnet:368:38-50	function <anonymous>```