### PR TITLE
(fix) demo-pipeline.jsonnet

### DIFF
--- a/demo/demo-pipeline.jsonnet
+++ b/demo/demo-pipeline.jsonnet
@@ -175,7 +175,7 @@ local findArtifactsFromResource = sponnet.stages
 
 local bakeManifest = sponnet.stages
                      .bakeManifest('Bake a manifest')
-                     .withReleaseName(app)
+                     .withReleaseOutputName(app)
                      .withNamespace('default')
                      .withTemplateArtifact(sponnet.inputArtifact(expectedHelm.id).fromAccount("s3"))
                      .withValueArtifacts([sponnet.inputArtifact(expectedManifest.id).fromAccount("gitlab")])


### PR DESCRIPTION
Fixes `RUNTIME ERROR: Field does not exist: withReleaseName` in `demo-pipeline.jsonnet`:
```
$-: jsonnet demo-pipeline.jsonnet
RUNTIME ERROR: Field does not exist: withReleaseName
	demo-pipeline.jsonnet:(176:22)-(178:38)	thunk <bakeManifest> from <$>
	demo-pipeline.jsonnet:210:134-146	thunk from <thunk from <$>>
	During manifestation
```
