### PR TITLE
Add missing static attribute to scaleManifest, patchManifest

### DIFF
--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -379,6 +379,7 @@
     },
     patchManifest(name):: stage(name, 'patchManifest') {
       cloudProvider: 'kubernetes',
+      mode: 'static',
       source: 'text',
       options: {
         mergeStrategy: 'strategic',

--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -391,6 +391,7 @@
     },
     scaleManifest(name): stage(name, 'scaleManifest') {
       cloudProvider: 'kubernetes',
+      mode: 'static',
       withAccount(account):: self + { account: account },
       withNamespace(namespace):: self + { location: namespace },
       withReplicas(replicas):: self + { replicas: replicas },


### PR DESCRIPTION
Without this, it gets added every time the pipeline is opened in the Spinnaker UI