### PR TITLE
Add missing app: application attribute to patchManifest

### DIFF
--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -384,6 +384,7 @@
         mergeStrategy: 'strategic',
         record: true,
       },
+      withApplication(application):: self + { app: application },
       withAccount(account):: self + { account: account },
       withNamespace(namespace):: self + { location: namespace },
       withPatchBody(patchBody):: self + { patchBody: patchBody },


### PR DESCRIPTION
When you open the pipeline step in the Spinnaker UI, it automatically adds this attribute so I think it's required.