### PR TITLE
Add missing function to add parameters to pipelines using pipeline templates

### DIFF
--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -25,6 +25,7 @@
     withSchema(schema):: self + { schema: schema },
     withInherit(inheritedFields):: self + if std.type(inheritedFields) == 'array' then { inherit: inheritedFields } else { inherit: [inheritedFields] },
     withVariableValues(variables):: self + { variables: variables },  // variables are key-value pairs of <variable name> -> <variable value>
+    withTemplateParameters(parameters):: self + if std.type(parameters) == 'array' then { parameters: parameters } else { parameters: [parameters] },
   },
 
   moniker(app, cluster=null):: {


### PR DESCRIPTION
When creating a pipeline from a pipeline template, parameters can be added using the `parameters` key. Looks like this function was missing.

See: https://spinnaker.io/reference/pipeline/templates/#pipeline-json

Thought about updating the name of the existing function `withParameters` to `withParameterConfig`, and adding this new function as `withParameters` but figured that wouldn't be backwards compatible and those using sponnet would get some weird behavior when upgrading. 