### PR TITLE
artifact entry instead of id

### DIFF
--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -99,7 +99,7 @@
   },
 
   inputArtifact(id):: {
-    id: id,
+    artifact: id,
     fromAccount(account):: self + {
       account: account,
     },


### PR DESCRIPTION
When calling this function in a pipeline template, it will generate an invalid inputartifact json model.
Example:

```diff
--- sponnet.json	2021-01-04 18:35:13.000000000 +0200
+++ spinnaker.json	2021-01-04 18:35:07.000000000 +0200
@@ -1,12 +1,12 @@
 "inputArtifacts": [
    {
       "account": "my-apps",
-      "id": {
+      "artifact": {
          "artifactAccount": "my-apps",
          "kind": "helm",
          "name": "generic-app",
          "type": "helm/chart",
          "version": "0.1.4"
       }
    }
 ]
```
