### PR TITLE
fix(sponnet): Remove `accounts`

### DIFF
--- a/application.libsonnet
+++ b/application.libsonnet
@@ -17,7 +17,6 @@
     },
     trafficGuards: [],
     // set overrides
-    withAccounts(accounts):: self + if std.type(accounts) == 'array' then { accounts: accounts } else { accounts: [accounts] },
     withAliases(aliases):: self + { aliases: aliases },
     withClusters(clusters):: self + if std.type(clusters) == 'array' then { clusters: clusters } else { clusters: [clusters] },
     withCloudProviders(cloudProviders):: self + { cloudProviders: cloudProviders },


### PR DESCRIPTION
This change removes `accounts` from `application` as it's a dynamically
updated field by Spinnaker.

Issue: spinnaker/spinnaker#6411