### PR TITLE
Add `#withRunAsUser` to pipeline trigger

### DIFF
--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -195,6 +195,7 @@
       application: application,
       pipeline: pipeline,
       status: statuses,
+      withRunAsUser(runAsUser):: self + { runAsUser: runAsUser },
     },
     cron(name, cronExpression):: trigger(name, 'cron') {
       cronExpression: cronExpression,


### PR DESCRIPTION
We have some pipeline triggers with the "Run As User" option enabled. Currently, Jsonnet fails to generate the pipeline when I try to add the `runAsUser` field. This PR adds `withRunAsUser` to pipeline trigger analogous to `docker` trigger.

Question: Should we add this field to `trigger` instead? I found this DTO, but I am not sure it can be used in all trigger types. https://github.com/spinnaker/echo/blob/a8268288da3ab342ac81234be4ae60fc18217bd6/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java#L59