### PR TITLE
Add `#withWaitForCompletion` to webhook stage

### DIFF
--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -461,6 +461,7 @@
       withMethod(method):: self + { method: method },
       withPayload(payload):: self + { payload: payload },
       withStatusUrlResolution(res):: self + { statusUrlResolution: res},
+      withWaitForCompletion(waitForCompletion):: self + { waitForCompletion: waitForCompletion },
     },
 
   },


### PR DESCRIPTION
Analogous to https://github.com/spinnaker/sponnet/pull/33, `waitForCompletion` was missing for the webhook stage.