### PR TITLE
Updated withPipeline in pipeline stage

### DIFF
--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -432,7 +432,7 @@
 
     pipeline(name):: stage(name, 'pipeline') {
       withApplication(application):: self + { application: application },
-      withPipeline(pipeline):: self + { pipeline: self.application + '-' + pipeline },
+      withPipeline(pipeline):: self + { pipeline: pipeline },
       withWaitForCompletion(waitForCompletion):: self + { waitForCompletion: waitForCompletion },
       withPipelineParameters(parameters):: self + { pipelineParameters: parameters },
       addPipelineParameter(key, value):: self + { pipelineParameters: super.pipelineParameters + { [key]: value } },


### PR DESCRIPTION
withPipeline should take a pipeline ID and not the pipeline application + name on spinnaker, since spinnaker expects an ID.  As it is right now, it doesn't work.
Maybe I could update the parameter name to pipelineId but I think it's fine as is